### PR TITLE
Performance Tweaks

### DIFF
--- a/src/main/java/darkdata/repository/DataVariableRepository.java
+++ b/src/main/java/darkdata/repository/DataVariableRepository.java
@@ -3,6 +3,7 @@ package darkdata.repository;
 import darkdata.datasource.DarkDataDatasource;
 import darkdata.model.kb.DataVariable;
 import darkdata.model.ontology.DarkData;
+import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,11 @@ public class DataVariableRepository {
 
     public Optional<DataVariable> createDataVariable(String uri) {
         return Optional.ofNullable(datasource.getOntModel().createIndividual(uri, DarkData.DataVariable))
+                .map(DataVariable::new);
+    }
+
+    public Optional<DataVariable> createDataVariable(OntModel m, String uri) {
+        return Optional.ofNullable(m.createIndividual(uri, DarkData.DataVariable))
                 .map(DataVariable::new);
     }
 

--- a/src/main/java/darkdata/repository/DatasetRepository.java
+++ b/src/main/java/darkdata/repository/DatasetRepository.java
@@ -3,6 +3,7 @@ package darkdata.repository;
 import darkdata.datasource.DarkDataDatasource;
 import darkdata.model.kb.Dataset;
 import darkdata.model.ontology.DarkData;
+import org.apache.jena.ontology.OntModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,11 @@ public class DatasetRepository {
 
     public Optional<Dataset> createDataset(String uri) {
         return Optional.ofNullable(datasource.getOntModel().createIndividual(uri, DarkData.Dataset))
+                .map(Dataset::new);
+    }
+
+    public Optional<Dataset> createDataset(OntModel m, String uri) {
+        return Optional.ofNullable(m.createIndividual(uri, DarkData.Dataset))
                 .map(Dataset::new);
     }
 }

--- a/src/main/java/darkdata/transformers/DataVariableAPI2KBConverter.java
+++ b/src/main/java/darkdata/transformers/DataVariableAPI2KBConverter.java
@@ -4,9 +4,13 @@ import darkdata.model.kb.Dataset;
 import darkdata.repository.DataVariableRepository;
 import darkdata.repository.DatasetRepository;
 import darkdata.web.api.datavariable.DataVariable;
+import org.apache.jena.ontology.OntModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 
 import java.util.Optional;
 
@@ -23,7 +27,9 @@ public class DataVariableAPI2KBConverter implements Converter<DataVariable, Opti
     @Autowired
     private DatasetRepository datasetRepository;
 
-    // do I need to set m?
+    private OntModel ontModel;
+
+    private static final Logger logger = LoggerFactory.getLogger(DataVariableAPI2KBConverter.class);
 
     @Override
     public Optional<darkdata.model.kb.DataVariable> convert(DataVariable variable) {
@@ -35,17 +41,29 @@ public class DataVariableAPI2KBConverter implements Converter<DataVariable, Opti
         String varId = variable.getProduct()+"_"+variable.getVersion()+"_"+variable.getVariable();
         String varURI = "urn:variable/"+varId;
 
-        darkdata.model.kb.DataVariable var = variableRepository.createDataVariable(varURI).get();
+        darkdata.model.kb.DataVariable var = variableRepository.createDataVariable(ontModel, varURI).get();
 
         String datasetID = variable.getProduct()+"_"+variable.getVersion();
         String datasetURI = "urn:dataset/"+datasetID;
 
-        Dataset dataset = datasetRepository.createDataset(datasetURI).get();
+        Dataset dataset = datasetRepository.createDataset(ontModel, datasetURI).get();
         dataset.setShortName(variable.getProduct());
+        Assert.isTrue(dataset.getShortName().isPresent(), "dataset should have a short name");
 
         var.setShortName(variable.getVariable());
+        Assert.isTrue(var.getShortName().isPresent(), "variable should have a short name");
+
         var.setDataset(dataset);
+        Assert.isTrue(var.getDataset().isPresent(), "variable should have an associated dataset");
 
         return Optional.of(var);
+    }
+
+    public OntModel getOntModel() {
+        return ontModel;
+    }
+
+    public void setOntModel(OntModel ontModel) {
+        this.ontModel = ontModel;
     }
 }

--- a/src/main/java/darkdata/transformers/DataVariableConverter.java
+++ b/src/main/java/darkdata/transformers/DataVariableConverter.java
@@ -5,8 +5,11 @@ import darkdata.model.kb.Dataset;
 import darkdata.model.kb.IndividualProxy;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 
 import java.util.Optional;
 
@@ -16,6 +19,8 @@ import java.util.Optional;
 @Component
 public class DataVariableConverter implements Converter<DataVariable, Optional<darkdata.web.api.datavariable.DataVariable>> {
 
+    private static final Logger logger = LoggerFactory.getLogger(DataVariableConverter.class);
+
     @Override
     public Optional<darkdata.web.api.datavariable.DataVariable> convert(DataVariable dataVariable) {
 
@@ -23,14 +28,20 @@ public class DataVariableConverter implements Converter<DataVariable, Optional<d
             return Optional.empty();
         }
 
+        logger.info("in DataVariableConverter::convert with {}", dataVariable.getIndividual().getURI());
+
         darkdata.web.api.datavariable.DataVariable var = new darkdata.web.api.datavariable.DataVariable();
 
         dataVariable.getDataset()
                 .flatMap(Dataset::getShortName)
                 .ifPresent(var::setProduct);
 
+        Assert.isTrue(dataVariable.getShortName().isPresent(), "data variable does not have short name");
+
         dataVariable.getShortName()
                 .ifPresent(var::setVariable);
+
+        Assert.isTrue(dataVariable.getDataset().isPresent(), "data variable does not have dataset");
 
         dataVariable.getDataset()
                 .map(IndividualProxy::getIndividual)

--- a/src/test/java/darkdata/service/GenerateCandidateWorkflowServiceTest.java
+++ b/src/test/java/darkdata/service/GenerateCandidateWorkflowServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,9 +53,7 @@ public class GenerateCandidateWorkflowServiceTest {
 
         for(CandidateWorkflow candidate : candidates) {
             Assert.assertTrue(candidate.getFeature().isPresent());
-            //System.out.println("getting physical features:\t" +  LocalDateTime.now());
             PhysicalFeature feature = candidate.getFeature().get();
-            //System.out.println("getting observable properties:\t" +  LocalDateTime.now());
             Assert.assertFalse(feature.observableProperties().isEmpty());
             Assert.assertTrue(candidate.getService().isPresent());
             Assert.assertTrue(candidate.getVariable().isPresent());

--- a/src/test/java/darkdata/service/RecommendationServiceTest.java
+++ b/src/test/java/darkdata/service/RecommendationServiceTest.java
@@ -42,5 +42,7 @@ public class RecommendationServiceTest {
         Assert.assertNotNull(requestObj);
         RecommendationResponse response = service.getRecommendation(requestObj);
         Assert.assertNotNull(response);
+
+        System.out.println(mapper.writeValueAsString(response));
     }
 }


### PR DESCRIPTION
- changed for-loop structure in candidate generation service to be more efficient
- create RDF instances in non-inferring OntModel
- repository and Converter classes now take a reference to the OntModel that should be used to create in instance

Refactoring to reduce unnecessary usage of inferring OntModel as that causes significant slowdown as reasoning is applied each time the model is updated.  For loop logic has been updated to improve efficiency.