### PR TITLE
Update rules to ensure unique compatibility assertion bnodes

### DIFF
--- a/rules/Rules.md
+++ b/rules/Rules.md
@@ -1,6 +1,77 @@
 Rules
 =====
 
-| Rule | Author |
--------|---------
-| For a short-time-duration event (say, a few days), you would want to return the daily L3 variables, but probably not the monthly | Chris Lynnes |
+## [Candidate Generation Ruleset](candidate-generation/generate_candidates.rules)
+
+Rules that generate candidate workflow resources based on events and datafields (aka variables) in requests.
+
+example:
+```
+[one-var-candidates:
+ (?criteria rdf:type dd:RequestCriteria),
+ (?criteria dd:criteriaDataField ?datafield),
+ (?criteria dd:criteriaEvent ?event),
+ (?service rdf:type dd:OneVariableVisualization),
+ (?event dd:physicalManifestation ?feature),
+ makeSkolem(?candidate, ?criteria, ?service, ?event, ?feature, ?datafield)
+ ->
+ (?candidate rdf:type dd:CandidateWorkflow),
+ (?candidate dd:candidateEvent ?event),
+ (?candidate dd:candidateService ?service),
+ (?candidate dd:candidateVariable ?datafield),
+ (?candidate dd:candidateFeature ?feature),
+ (?criteria dd:candidate ?candidate)
+]
+```
+
+These rules currently generate a candidate workflow for every variable in the datafield in the request and every service known to the knowledge base.
+
+## [Compatibility Assertion Rulesets](compatibility-assertion-generation)
+
+Rulesets containing rules that generate compatibility assertions based on the combination of some criteria from the candidate.
+
+### [characteristic compatibility ruleset](compatibility-assertion-generation/generate_candidates.rules)
+
+Generates compatibility assertions for service/feature combinations based on the feature characteristics the service is best for visualizing and the applicability of the feature characteristic to analyzing the feature
+
+example:
+```
+[strong-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:strongCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/strong-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]
+```
+
+### [time interval ruleset](compatibility-assertion-generation/time_interval.rules)
+
+Generates compatibility assertions for event/time interval pairings.
+
+example:
+
+```
+[hurricane-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-hourly>)
+]
+```

--- a/rules/candidate-generation/generate_candidates.rules
+++ b/rules/candidate-generation/generate_candidates.rules
@@ -1,0 +1,52 @@
+@prefix dd: <http://www.purl.org/twc/ns/darkdata#>.
+
+[one-var-candidates:
+ (?criteria rdf:type dd:RequestCriteria),
+ (?criteria dd:criteriaDataField ?datafield),
+ (?criteria dd:criteriaEvent ?event),
+ (?service rdf:type dd:OneVariableVisualization),
+ (?event dd:physicalManifestation ?feature),
+ makeSkolem(?candidate, ?criteria, ?service, ?event, ?feature, ?datafield)
+ ->
+ (?candidate rdf:type dd:CandidateWorkflow),
+ (?candidate dd:candidateEvent ?event),
+ (?candidate dd:candidateService ?service),
+ (?candidate dd:candidateVariable ?datafield),
+ (?candidate dd:candidateFeature ?feature),
+ (?criteria dd:candidate ?candidate)
+]
+
+# will 2 candidates be generated for each datafield combination?
+[two-var-candidates:
+ (?criteria rdf:type dd:RequestCriteria),
+ (?criteria dd:criteriaDataField ?datafield1),
+ (?criteria dd:criteriaDataField ?datafield2),
+ notEqual(?datafield1, ?datafield2),
+ (?criteria dd:criteriaEvent ?event),
+ (?event dd:physicalManifestation ?feature),
+ (?service rdf:type dd:TwoVariableVisualization),
+ makeSkolem(?candidate, ?criteria, ?service, ?event, ?feature, ?datafield1, ?datafield2)
+ ->
+ (?candidate rdf:type dd:CandidateWorkflow),
+ (?candidate dd:candidateFeature ?feature),
+ (?candidate dd:candidateEvent ?event),
+ (?candidate dd:candidateService ?service),
+ (?candidate dd:candidateVariable ?datafield1),
+ (?candidate dd:candidateVariable ?datafield2),
+ (?criteria dd:candidate ?candidate)
+]
+
+[candidates-event-only:
+ (?criteria rdf:type dd:RequestCriteria),
+ noValue(?criteria dd:criteriaDataField ?datafield),
+ (?criteria dd:criteriaEvent ?event),
+ (?service rdf:type dd:Visualization),
+ (?event dd:physicalManifestation ?feature),
+ makeSkolem(?candidate, ?criteria, ?service, ?event, ?feature)
+ ->
+ (?candidate rdf:type dd:CandidateWorkflow),
+ (?candidate dd:candidateEvent ?event),
+ (?candidate dd:candidateService ?service),
+ (?candidate dd:candidateFeature ?feature),
+ (?criteria dd:candidate ?candidate)
+]

--- a/rules/compatibility-assertion-generation/characteristic_compatibility.rules
+++ b/rules/compatibility-assertion-generation/characteristic_compatibility.rules
@@ -1,0 +1,204 @@
+@prefix dd: <http://www.purl.org/twc/ns/darkdata#>.
+
+[windfield-characteristic-compatibilities:
+ (?feature rdf:type dd:WindFields)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:indifferentCompatibilityFor dd:east-west-movement),
+ (?feature dd:indifferentCompatibilityFor dd:north-south-movement),
+ (?feature dd:slightCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:indifferentCompatibilityFor dd:seasonal_variation),
+ (?feature dd:indifferentCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:strongCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:someCompatibilityFor dd:global_phenomena),
+ (?feature dd:slightCompatibilityFor dd:detection_of_events)
+]
+
+[hurricane-eye-characteristic-compatibilities:
+ (?feature rdf:type dd:HurricaneEye)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:strongCompatibilityFor dd:variation_with_atmospheric_height)
+]
+
+[ash-plume-characteristic-compatibilities:
+ (?feature rdf:type dd:AshPlume)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:indifferentCompatibilityFor dd:east-west-movement),
+ (?feature dd:indifferentCompatibilityFor dd:north-south-movement),
+ (?feature dd:slightCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:strongCompatibilityFor dd:seasonal_variation),
+ (?feature dd:strongCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:strongCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:strongCompatibilityFor dd:global_phenomena),
+ (?feature dd:strongCompatibilityFor dd:detection_of_events)
+]
+
+[landslide-characteristic-compatibilities:
+ (?feature rdf:type dd:Landslide)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:someCompatibilityFor dd:east-west-movement),
+ (?feature dd:someCompatibilityFor dd:north-south-movement),
+ (?feature dd:strongCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:someCompatibilityFor dd:seasonal_variation),
+ (?feature dd:someCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:indifferentCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:someCompatibilityFor dd:global_phenomena),
+ (?feature dd:strongCompatibilityFor dd:detection_of_events)
+]
+
+[air-quality-characteristic-compatibilities:
+ (?feature rdf:type dd:AirQuality)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:slightCompatibilityFor dd:east-west-movement),
+ (?feature dd:slightCompatibilityFor dd:north-south-movement),
+ (?feature dd:strongCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:strongCompatibilityFor dd:seasonal_variation),
+ (?feature dd:strongCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:strongCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:slightCompatibilityFor dd:global_phenomena),
+ (?feature dd:slightCompatibilityFor dd:detection_of_events)
+]
+
+[dust-plume-characteristic-compatibilities:
+ (?feature rdf:type dd:DustPlume)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:strongCompatibilityFor dd:east-west-movement),
+ (?feature dd:strongCompatibilityFor dd:north-south-movement),
+ (?feature dd:strongCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:indifferentCompatibilityFor dd:seasonal_variation),
+ (?feature dd:indifferentCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:strongCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:indifferentCompatibilityFor dd:global_phenomena),
+ (?feature dd:someCompatibilityFor dd:detection_of_events)
+]
+
+[stationary-water-vapor-anomaly-characteristic-compatibilities:
+ (?feature rdf:type dd:StationaryWaterVaporAnomaly)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:strongCompatibilityFor dd:east-west-movement),
+ (?feature dd:strongCompatibilityFor dd:north-south-movement),
+ (?feature dd:strongCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:strongCompatibilityFor dd:seasonal_variation),
+ (?feature dd:someCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:someCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:strongCompatibilityFor dd:global_phenomena),
+ (?feature dd:strongCompatibilityFor dd:detection_of_events)
+]
+
+[weather-characteristic-compatibilities:
+ (?feature rdf:type dd:Weather)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:someCompatibilityFor dd:east-west-movement),
+ (?feature dd:someCompatibilityFor dd:north-south-movement),
+ (?feature dd:someCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:strongCompatibilityFor dd:seasonal_variation),
+ (?feature dd:someCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:someCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:slightCompatibilityFor dd:global_phenomena),
+ (?feature dd:someCompatibilityFor dd:detection_of_events)
+]
+
+[precipitation-characteristic-compatibilities:
+ (?feature rdf:type dd:Precipitation)
+ ->
+ (?feature dd:strongCompatibilityFor dd:temporal_evolution),
+ (?feature dd:strongCompatibilityFor dd:east-west-movement),
+ (?feature dd:strongCompatibilityFor dd:north-south-movement),
+ (?feature dd:strongCompatibilityFor dd:spatial_extent_of_event),
+ (?feature dd:strongCompatibilityFor dd:seasonal_variation),
+ (?feature dd:strongCompatibilityFor dd:year-to-year-variability),
+ (?feature dd:slightCompatibilityFor dd:variation_with_atmospheric_height),
+ (?feature dd:slightCompatibilityFor dd:global_phenomena),
+ (?feature dd:someCompatibilityFor dd:detection_of_events)
+]
+
+# make assertions based on
+# feature to characteristic compatibility
+# service is best for characteristic
+
+[strong-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:strongCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/strong-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]
+
+[slight-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:slightCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:slight_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/slight-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]
+
+[some-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:someCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/some-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]
+
+[indifferent-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:indifferentCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:indifferent_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/indifferent-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]
+
+[negative-compatibility:
+ (?candidate dd:candidateFeature ?feature),
+ (?feature dd:negativeCompatibilityFor ?characteristic),
+ (?candidate dd:candidateService ?service),
+ (?service dd:bestFor ?characteristic),
+ makeSkolem(?assertion, ?service, ?feature, ?characteristic)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:negative_compatibility),
+ (?assertion dd:assertionConfidence "1.0"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/characteristic_compatibility/negative-compatibility>),
+ (?assertion dd:evidenceForAssertion ?characteristic),
+ (?assertion dd:evidenceForAssertion ?feature)
+]

--- a/rules/compatibility-assertion-generation/time_interval.rules
+++ b/rules/compatibility-assertion-generation/time_interval.rules
@@ -1,0 +1,540 @@
+@prefix dd: <http://www.purl.org/twc/ns/darkdata#> .
+
+# Hurricane
+
+[hurricane-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-half-hourly>)
+]
+
+[hurricane-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-hourly>)
+]
+
+[hurricane-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-3-hourly>)
+]
+
+[hurricane-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-daily>)
+]
+
+[hurricane-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Hurricane),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:Hurricane, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:negative_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/hurricane-monthly>)
+]
+
+# SevereStorm
+
+[severe-storm-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:SevereStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:SevereStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/severe-storm-half-hourly>)
+]
+
+[severe-storm-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:SevereStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:SevereStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/severe-storm-hourly>)
+]
+
+[severe-storm-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:SevereStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:SevereStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/severe-storm-3-hourly>)
+]
+
+[severe-storm-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:SevereStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:SevereStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/severe-storm-daily>)
+]
+
+[severe-storm-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:SevereStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:SevereStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:negative_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/severe-storm-monthly>)
+]
+
+# VolcanicEruption
+
+[volcanic-eruption-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:VolcanicEruption),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:VolcanicEruption, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/volcanic-eruption-half-hourly>)
+]
+
+[volcanic-eruption-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:VolcanicEruption),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:VolcanicEruption, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/volcanic-eruption-hourly>)
+]
+
+[volcanic-eruption-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:VolcanicEruption),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:VolcanicEruption, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/volcanic-eruption-3-hourly>)
+]
+
+[volcanic-eruption-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:VolcanicEruption),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:VolcanicEruption, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/volcanic-eruption-daily>)
+]
+
+[volcanic-eruption-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:VolcanicEruption),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:VolcanicEruption, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:indifferent_compatibility),
+ (?assertion dd:assertionConfidence "0.25"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/volcanic-eruption-monthly>)
+]
+
+# Flood
+
+[flood-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Flood),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:Flood, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/flood-half-hourly>)
+]
+
+[flood-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Flood),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:Flood, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/flood-hourly>)
+]
+
+[flood-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Flood),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:Flood, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/flood-3-hourly>)
+]
+
+[flood-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Flood),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:Flood, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/flood-daily>)
+]
+
+[flood-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Flood),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:Flood, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:negative_compatibility),
+ (?assertion dd:assertionConfidence "0.25"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/flood-monthly>)
+]
+
+# Wildfire
+
+[wildfire-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Wildfire),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:Wildfire, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/wildfire-half-hourly>)
+]
+
+[wildfire-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Wildfire),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:Wildfire, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/wildfire-hourly>)
+]
+
+[wildfire-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Wildfire),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:Wildfire, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/wildfire-3-hourly>)
+]
+
+[wildfire-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Wildfire),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:Wildfire, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/wildfire-daily>)
+]
+
+[wildfire-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Wildfire),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:Wildfire, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:indifferent_compatibility),
+ (?assertion dd:assertionConfidence "0.25"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/wildfire-monthly>)
+]
+
+# DustStorm
+
+[dust-storm-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:DustStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:DustStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/dust-storm-half-hourly>)
+]
+
+[dust-storm-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:DustStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:DustStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/dust-storm-hourly>)
+]
+
+[dust-storm-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:DustStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:DustStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/dust-storm-3-hourly>)
+]
+
+[dust-storm-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:DustStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:DustStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/dust-storm-daily>)
+]
+
+[dust-storm-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:DustStorm),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:DustStorm, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:negative_compatibility),
+ (?assertion dd:assertionConfidence "0.25"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/dust-storm-monthly>)
+]
+
+# Drought
+
+[drought-half-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Drought),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, dd:Drought, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/drought-half-hourly>)
+]
+
+[drought-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Drought),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, dd:Drought, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/drought-hourly>)
+]
+
+[drought-3-hourly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Drought),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, dd:Drought, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:some_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/drought-3-hourly>)
+]
+
+[drought-daily:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Drought),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, dd:Drought, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:strong_compatibility),
+ (?assertion dd:assertionConfidence "0.5"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/drought-daily>)
+]
+
+[drought-monthly:
+ (?candidate dd:candidateEvent ?event),
+ (?event rdf:type dd:Drought),
+ (?candidate dd:candidateVariable ?variable),
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, dd:Drought, ?timeInterval)
+ ->
+ (?candidate dd:compatibilityAssertion ?assertion),
+ (?assertion rdf:type dd:CompatibilityAssertion),
+ (?assertion dd:compatibilityValue dd:indifferent_compatibility),
+ (?assertion dd:assertionConfidence "0.25"^^xsd:double),
+ (?assertion dd:basisForAssertion <urn:rule/time_interval/drought-monthly>)
+]

--- a/src/main/resources/rules/time_interval.rules
+++ b/src/main/resources/rules/time_interval.rules
@@ -6,8 +6,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Hurricane),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -20,8 +21,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Hurricane),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -34,8 +36,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Hurricane),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -48,8 +51,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Hurricane),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -62,8 +66,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Hurricane),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Hurricane, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -78,8 +83,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:SevereStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -92,8 +98,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:SevereStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -106,8 +113,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:SevereStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -120,8 +128,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:SevereStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -134,8 +143,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:SevereStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:SevereStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -150,8 +160,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:VolcanicEruption),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -164,8 +175,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:VolcanicEruption),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -178,8 +190,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:VolcanicEruption),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -192,8 +205,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:VolcanicEruption),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -206,8 +220,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:VolcanicEruption),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:VolcanicEruption, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -222,8 +237,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Flood),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -236,8 +252,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Flood),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -250,8 +267,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Flood),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -264,8 +282,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Flood),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -278,8 +297,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Flood),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Flood, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -294,8 +314,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Wildfire),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -308,8 +329,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Wildfire),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -322,8 +344,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Wildfire),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -336,8 +359,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Wildfire),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -350,8 +374,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Wildfire),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Wildfire, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -366,8 +391,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:DustStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -380,8 +406,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:DustStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -394,8 +421,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:DustStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -408,8 +436,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:DustStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -422,8 +451,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:DustStorm),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:DustStorm, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -438,8 +468,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Drought),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/half-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -452,8 +483,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Drought),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -466,8 +498,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Drought),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/3-hourly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -480,8 +513,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Drought),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/daily>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),
@@ -494,8 +528,9 @@
  (?candidate dd:candidateEvent ?event),
  (?event rdf:type dd:Drought),
  (?candidate dd:candidateVariable ?variable),
- (?variable dd:timeInterval <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
- makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable)
+ (?variable dd:timeInterval ?timeInterval),
+ equal(?timeInterval, <http://darkdata.tw.rpi.edu/data/time-interval/monthly>),
+ makeSkolem(?assertion, ?candidate, ?event, dd:Drought, ?variable, ?timeInterval)
  ->
  (?candidate dd:compatibilityAssertion ?assertion),
  (?assertion rdf:type dd:CompatibilityAssertion),


### PR DESCRIPTION
updated the makeSkolem() call in rules to ensure the assertion bnode does not collide with assertion bnodes from other rulesets